### PR TITLE
Fixing a small bug

### DIFF
--- a/lib/easy_translate/detection.rb
+++ b/lib/easy_translate/detection.rb
@@ -9,7 +9,7 @@ module EasyTranslate
     # @param [String, Array] texts - A single string or set of strings to detect for
     # @param [Hash] options - Extra options to pass along with the request
     # @return [String, Array] The resultant language or languages
-    def detect(texts, options = nil, http_options={})
+    def detect(texts, options = {}, http_options={})
       request = DetectionRequest.new(texts, options, http_options)
       # Turn the response into an array of detections
       raw = request.perform_raw


### PR DESCRIPTION
Without this change I got nasty errors like this:

`>> EasyTranslate.detect("Hello")
NoMethodError: undefined method `delete' for nil:NilClass
    from /srv/apprentus/vendor/bundle/ruby/1.9.1/gems/easy_translate-0.3.2/lib/easy_translate/detection.rb:31:in `initialize'
    from /srv/apprentus/vendor/bundle/ruby/1.9.1/gems/easy_translate-0.3.2/lib/easy_translate/detection.rb:13:in `new'
    from /srv/apprentus/vendor/bundle/ruby/1.9.1/gems/easy_translate-0.3.2/lib/easy_translate/detection.rb:13:in `detect'
    from (irb):19
    from /srv/apprentus/vendor/bundle/ruby/1.9.1/gems/railties-3.2.11/lib/rails/commands/console.rb:47:in `start'
    from /srv/apprentus/vendor/bundle/ruby/1.9.1/gems/railties-3.2.11/lib/rails/commands/console.rb:8:in `start'
    from /srv/apprentus/vendor/bundle/ruby/1.9.1/gems/railties-3.2.11/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'`
