### PR TITLE
Content after ampersand is truncated

### DIFF
--- a/lib/easy_translate/detection.rb
+++ b/lib/easy_translate/detection.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'cgi'
 require File.dirname(__FILE__) + '/request'
 
 module EasyTranslate
@@ -51,7 +52,7 @@ module EasyTranslate
       # The body for the request
       # @return [String] the body for the request, URL escaped
       def body
-        @texts.map { |t| "q=#{URI.escape(t)}" }.join '&'
+        @texts.map { |t| "q=#{CGI::escape(t)}" }.join '&'
       end
 
       # Whether or not this was a request for multiple texts

--- a/lib/easy_translate/translation.rb
+++ b/lib/easy_translate/translation.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'cgi'
 require File.dirname(__FILE__) + '/request'
 
 module EasyTranslate
@@ -64,7 +65,7 @@ module EasyTranslate
       # The body for the request
       # @return [String] the body for the request, URL escaped
       def body
-        @texts.map { |t| "q=#{URI.escape(t)}" }.join '&'
+        @texts.map { |t| "q=#{CGI::escape(t)}" }.join '&'
       end
 
       # Whether or not this was a request for multiple texts


### PR DESCRIPTION
Since URI.escape does not percent encode [and is deprecated], everything after a string that contains an ampersand is lost.
