### PR TITLE
Fix typo in TranslationRequest#initialize exception

### DIFF
--- a/lib/easy_translate/translation.rb
+++ b/lib/easy_translate/translation.rb
@@ -34,7 +34,7 @@ module EasyTranslate
         self.html = options.delete(:html)
         @source = options.delete(:from)
         @target = options.delete(:to)
-        raise ArgumentError.new('No target language provded') unless @target
+        raise ArgumentError.new('No target language provided') unless @target
         raise ArgumentError.new('Support for multiple targets dropped in V2') if @target.is_a?(Array)
         @http_options = http_options
         if options


### PR DESCRIPTION
Very quick fix, there was a typo in "No target language provided"

Found it while trying to run this example from the readme (which appears to miss a parameter):

```
# mention that you're submitting HTML (translate calls only)
EasyTranslate.translate("<b>Hello</b>", :html => true) # => "<b>¡Hola</b>"
```

Thanks for your Gem :+1: 
