### PR TITLE
Highlight Readme syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,48 +8,59 @@ I looked around a bit for a google translate library in Ruby that would perform 
 
 ### Installation
 
-    $ gem install easy_translate
+```bash
+$ gem install easy_translate
+```
 
 Or in your Gemfile:
 
-    gem 'easy_translate'
+```ruby
+gem 'easy_translate'
+```
 
 ---
 
 ### Single translation
 
-    # auto-detect
-    EasyTranslate.translate('Hello, world', :to => :spanish) # => "Hola, mundo"
-    EasyTranslate.translate('Hello, world', :to => 'es') # => "Hola, mundo"
+```ruby
+# auto-detect
+EasyTranslate.translate('Hello, world', :to => :spanish) # => "Hola, mundo"
+EasyTranslate.translate('Hello, world', :to => 'es') # => "Hola, mundo"
 
-    # feel free to specify explicitly 
-    EasyTranslate.translate('Hola, mundo', :from => :spanish, :to => :en) # => "Hello, world"
+# feel free to specify explicitly 
+EasyTranslate.translate('Hola, mundo', :from => :spanish, :to => :en) # => "Hello, world"
+```
 
 ---
 
 ### Batch translation (Yay!)
 
-    # multiple strings
-    EasyTranslate.translate(['Hello', 'Goodbye'], :to => :spanish) # => ["¡Hola", "Despedida"]
-
-		EasyTranslate.detect(['hello', 'hola, mundo']) # => ['en', 'es']
+```ruby
+# multiple strings
+EasyTranslate.translate(['Hello', 'Goodbye'], :to => :spanish) # => ["¡Hola", "Despedida"]
+EasyTranslate.detect(['hello', 'hola, mundo']) # => ['en', 'es']
+```
 
 ---
 
 ### API Keys
 
-    # make google happy - (NOTE: use these anywhere)
-    EasyTranslate.translate('Hello, world', :to => :es, :key => 'xxx')
+```ruby
+# make google happy - (NOTE: use these anywhere)
+EasyTranslate.translate('Hello, world', :to => :es, :key => 'xxx')
 
-    # don't want to set the key on every call? ** Me either! **
-    EasyTranslate.api_key = 'xxx'
+# don't want to set the key on every call? ** Me either! **
+EasyTranslate.api_key = 'xxx'
+```
 
 ---
 
 ### Because you might be greedy and want detection, too
 
-    # detect language
-    EasyTranslate.detect "This is definitely English!" # => 'en'
+```ruby
+# detect language
+EasyTranslate.detect "This is definitely English!" # => 'en'
+```
 
 ### Google Translate supports HTML (default) and plain text formats
 
@@ -64,16 +75,20 @@ EasyTranslate.translate "Las doce <b>en punto</b>", :format => 'html', :to => :e
 
 ### List of languages
 
-    # list from <http://translate.google.com/>
-    EasyTranslate::LANGUAGES # => { 'en' => 'english', ... }
+```ruby
+# list from <http://translate.google.com/>
+EasyTranslate::LANGUAGES # => { 'en' => 'english', ... }
+```
 
 ### List of supported languages
 
-    # List all languages (from API)
-    EasyTranslate.translations_available
+```ruby
+# List all languages (from API)
+EasyTranslate.translations_available
 
-    # List all languages supported by some language
-    EasyTranslate.translations_available('zh-CN')
+# List all languages supported by some language
+EasyTranslate.translations_available('zh-CN')
+```
 
 ---
 


### PR DESCRIPTION
Highlight `ruby` blocks in Readme. 
By the way, I have a script for this: https://gist.github.com/glebm/6501313
