### PR TITLE
gemspec: require version using absolute path

### DIFF
--- a/easy_translate.gemspec
+++ b/easy_translate.gemspec
@@ -1,5 +1,4 @@
-$: << File.expand_path('lib', File.dirname(__FILE__))
-require 'easy_translate/version'
+require File.expand_path('lib/easy_translate/version', File.dirname(__FILE__))
 
 spec = Gem::Specification.new do |s|
   s.name = 'easy_translate'  


### PR DESCRIPTION
Apparently, modifying the load path in the gemspec results in the library being loaded twice when loaded via Gemfile `path` option: https://github.com/bundler/bundler/pull/2308
