### PR TITLE
Convert specs to RSpec 2.14.8 syntax with Transpec

### DIFF
--- a/spec/examples/detection_spec.rb
+++ b/spec/examples/detection_spec.rb
@@ -5,39 +5,39 @@ require 'spec_helper'
 describe EasyTranslate::Detection do
 
   it 'should return a single if given a single - from doc' do
-    EasyTranslate::Detection::DetectionRequest.should_receive(:new).and_return(OpenStruct.new({
+    expect(EasyTranslate::Detection::DetectionRequest).to receive(:new).and_return(OpenStruct.new({
       :perform_raw => '{"data":{"detections":[[{"language":"en","isReliable":false,"confidence":0.6595744}]]}}',
       :multi? => false
     }))
     lang = EasyTranslate.detect 'Google Translate Rocks'
-    lang.should == 'en'
+    expect(lang).to eq('en')
   end
 
   it 'should return a single with confidence if given a single with confidence - from doc' do
-    EasyTranslate::Detection::DetectionRequest.should_receive(:new).and_return(OpenStruct.new({
+    expect(EasyTranslate::Detection::DetectionRequest).to receive(:new).and_return(OpenStruct.new({
       :perform_raw => '{"data":{"detections":[[{"language":"en","isReliable":false,"confidence":0.6595744}]]}}',
       :multi? => false
     }))
     lang = EasyTranslate.detect 'Google Translate Rocks', :confidence => true
-    lang.should == { :language => 'en', :confidence => 0.6595744 }
+    expect(lang).to eq({ :language => 'en', :confidence => 0.6595744 })
   end
 
   it 'should return a multiple if given multiple - from doc' do
-    EasyTranslate::Detection::DetectionRequest.should_receive(:new).and_return(OpenStruct.new({
+    expect(EasyTranslate::Detection::DetectionRequest).to receive(:new).and_return(OpenStruct.new({
       :perform_raw => '{"data":{"detections":[[{"language":"en","isReliable":false,"confidence":0.6315789}],[{"language":"zh-CN","isReliable":false,"confidence":1.0}]]}}',
       :multi? => true
     }))
     lang = EasyTranslate.detect ['Hello World', '我姓譚']
-    lang.should == ['en', 'zh-CN']
+    expect(lang).to eq(['en', 'zh-CN'])
   end
 
   it 'should return a multiple with confidence if given multiple with confidence - from doc' do
-    EasyTranslate::Detection::DetectionRequest.should_receive(:new).and_return(OpenStruct.new({
+    expect(EasyTranslate::Detection::DetectionRequest).to receive(:new).and_return(OpenStruct.new({
       :perform_raw => '{"data":{"detections":[[{"language":"en","isReliable":false,"confidence":0.6315789}],[{"language":"zh-CN","isReliable":false,"confidence":1.0}]]}}',
       :multi? => true
     }))
     lang = EasyTranslate.detect ['Hello World', '我姓譚'], :confidence => true
-    lang.should == [{ :language => 'en', :confidence => 0.6315789 }, { :language => 'zh-CN', :confidence => 1.0 }]
+    expect(lang).to eq([{ :language => 'en', :confidence => 0.6315789 }, { :language => 'zh-CN', :confidence => 1.0 }])
   end
 
   klass = EasyTranslate::Detection::DetectionRequest
@@ -47,7 +47,7 @@ describe EasyTranslate::Detection do
 
       it 'should have a valid path' do
         request = klass.new('abc')
-        request.path.should_not be_empty
+        expect(request.path).not_to be_empty
       end
 
     end
@@ -56,17 +56,17 @@ describe EasyTranslate::Detection do
 
       it 'should insert the texts into the body' do
         request = klass.new(['abc', 'def'])
-        request.body.should == 'q=abc&q=def'
+        expect(request.body).to eq('q=abc&q=def')
       end
 
       it 'should insert the text into the body' do
         request = klass.new('abc')
-        request.body.should == 'q=abc'
+        expect(request.body).to eq('q=abc')
       end
 
       it 'should URI escape the body' do
         request = klass.new('%')
-        request.body.should == 'q=%25'
+        expect(request.body).to eq('q=%25')
       end
 
     end
@@ -76,20 +76,20 @@ describe EasyTranslate::Detection do
       it 'should use default params' do
         EasyTranslate.api_key = 'abc'
         request = klass.new('abc')
-        request.params[:key].should == 'abc'
+        expect(request.params[:key]).to eq('abc')
       end
 
       it 'should allow overriding of params' do
         EasyTranslate.api_key = 'abc'
         request = klass.new('abc', :key => 'def')
-        request.params[:key].should == 'def'
+        expect(request.params[:key]).to eq('def')
       end
 
       it 'should allow overriding of key as api_key' do
         EasyTranslate.api_key = 'abc'
         request = klass.new('abc', :api_key => 'def')
-        request.params[:key].should == 'def'
-        request.params[:api_key].should be_nil
+        expect(request.params[:key]).to eq('def')
+        expect(request.params[:api_key]).to be_nil
       end
 
     end
@@ -99,20 +99,20 @@ describe EasyTranslate::Detection do
       it 'should accept timeouts options' do
         request = EasyTranslate::Detection::DetectionRequest.new "test", {}, {:timeout => 1, :open_timeout => 2}
         http = request.send(:http)
-        http.open_timeout.should == 2
-        http.read_timeout.should == 1
+        expect(http.open_timeout).to eq(2)
+        expect(http.read_timeout).to eq(1)
       end
 
       it 'should accept ssl options' do
         request = EasyTranslate::Detection::DetectionRequest.new "test", {}, {:ssl => {:verify_depth => 3, :ca_file => 'path/to/ca/file'}}
         http = request.send(:http)
-        http.verify_depth.should == 3
-        http.ca_file.should == 'path/to/ca/file'
+        expect(http.verify_depth).to eq(3)
+        expect(http.ca_file).to eq('path/to/ca/file')
       end
 
       it 'should accept confidence option' do
         request = EasyTranslate::Detection::DetectionRequest.new "test", {:confidence => true}, {}
-        request.params[:confidence].should == true
+        expect(request.params[:confidence]).to eq(true)
       end
 
     end
@@ -121,17 +121,17 @@ describe EasyTranslate::Detection do
 
       it 'should be true if multiple are passed' do
         request = klass.new(['abc', 'def'])
-        request.should be_multi
+        expect(request).to be_multi
       end
 
       it 'should be true if one is passed, but in an array' do
         request = klass.new(['abc'])
-        request.should be_multi
+        expect(request).to be_multi
       end
 
       it 'should be true if one is passed as a string' do
         request = klass.new('abc')
-        request.should_not be_multi
+        expect(request).not_to be_multi
       end
 
     end

--- a/spec/examples/easy_translate_spec.rb
+++ b/spec/examples/easy_translate_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe EasyTranslate do
 
   it 'should have LANGUAGES' do
-    EasyTranslate::LANGUAGES.should be_a(Hash)
-    EasyTranslate::LANGUAGES['en'].should == 'english'
+    expect(EasyTranslate::LANGUAGES).to be_a(Hash)
+    expect(EasyTranslate::LANGUAGES['en']).to eq('english')
   end
 
   it 'should have a version' do
-    EasyTranslate::VERSION.split('.').length.should == 3
+    expect(EasyTranslate::VERSION.split('.').length).to eq(3)
   end
 
 end

--- a/spec/examples/real_world_spec.rb
+++ b/spec/examples/real_world_spec.rb
@@ -15,17 +15,17 @@ describe EasyTranslate do
 
     it 'should be able to translate one' do
       res = EasyTranslate.translate 'hello world', :to => :spanish
-      res.should == 'hola mundo'
+      expect(res).to eq('hola mundo')
     end
 
     it 'should be able to translate multiple' do
       res = EasyTranslate.translate ['hello world', 'i love you'], :to => :spanish
-      res.should == ['hola mundo', 'te amo']
+      expect(res).to eq(['hola mundo', 'te amo'])
     end
 
     it 'should work concurrently' do
       res = EasyTranslate.translate ['hello world', 'i love you', 'good morning'], :to => :spanish, :concurrency => 2, :batch_size => 1
-      res.should == ['hola mundo', 'te amo', '¡buenos días']
+      expect(res).to eq(['hola mundo', 'te amo', '¡buenos días'])
     end
   end
 
@@ -33,12 +33,12 @@ describe EasyTranslate do
 
     it 'should be able to detect one' do
       res = EasyTranslate.detect 'hello world'
-      res.should == 'en'
+      expect(res).to eq('en')
     end
 
     it 'should be able to translate one' do
       res = EasyTranslate.detect ['hello world', 'hola mundo']
-      res.should == ['en', 'es']
+      expect(res).to eq(['en', 'es'])
     end
 
   end
@@ -47,12 +47,12 @@ describe EasyTranslate do
 
     it 'should be able to get a list of all' do
       res = EasyTranslate.translations_available
-      res.should be_a Array
+      expect(res).to be_a Array
     end
 
     it 'should be able to get a list of all from es' do
       res = EasyTranslate.translations_available('yi')
-      res.should be_a Array
+      expect(res).to be_a Array
     end
 
   end

--- a/spec/examples/request_spec.rb
+++ b/spec/examples/request_spec.rb
@@ -6,9 +6,9 @@ describe EasyTranslate::Request do
 
     it 'should raise a NotImplementedError on this base class' do
       request = EasyTranslate::Request.new
-      lambda do
+      expect do
         request.path
-      end.should raise_error NotImplementedError
+      end.to raise_error NotImplementedError
     end
 
   end
@@ -17,7 +17,7 @@ describe EasyTranslate::Request do
 
     it 'should be blank by default' do
       request = EasyTranslate::Request.new
-      request.body.should be_empty
+      expect(request.body).to be_empty
     end
 
   end
@@ -27,12 +27,12 @@ describe EasyTranslate::Request do
     it 'should include the key if given at the base' do
       EasyTranslate.api_key = 'abc'
       request = EasyTranslate::Request.new
-      request.params[:key].should == 'abc'
+      expect(request.params[:key]).to eq('abc')
     end
 
     it 'should turn off prettyPrint' do
       request = EasyTranslate::Request.new
-      request.params[:prettyPrint].should == 'false'
+      expect(request.params[:prettyPrint]).to eq('false')
     end
 
   end
@@ -41,8 +41,8 @@ describe EasyTranslate::Request do
 
     it 'should skip nil parameters' do
       request = EasyTranslate::Request.new
-      request.should_receive(:params).and_return({ :something => nil })
-      request.send(:param_s).should be_empty
+      expect(request).to receive(:params).and_return({ :something => nil })
+      expect(request.send(:param_s)).to be_empty
     end
 
   end

--- a/spec/examples/translation_spec.rb
+++ b/spec/examples/translation_spec.rb
@@ -8,7 +8,7 @@ describe EasyTranslate::Translation do
       :multi? => false
     )
     trans = EasyTranslate.translate 'Hello world', :to => 'de'
-    trans.should == 'Hallo Welt'
+    expect(trans).to eq('Hallo Welt')
   end
 
   it 'should return a multiple if given multiple - from doc' do
@@ -17,7 +17,7 @@ describe EasyTranslate::Translation do
       :multi? => true
     )
     trans = EasyTranslate.translate ['Hello world', 'my name is jeff'], :to => 'de'
-    trans.should == ['Hallo Welt', 'Mein Name ist Jeff']
+    expect(trans).to eq(['Hallo Welt', 'Mein Name ist Jeff'])
   end
 
   it 'should decode HTML entities in the response' do
@@ -26,11 +26,11 @@ describe EasyTranslate::Translation do
       :multi? => false
     )
     trans = EasyTranslate.translate %{Hello ' & " world}, :to => 'de'
-    trans.should == %{Hallo ' & " Welt}
+    expect(trans).to eq(%{Hallo ' & " Welt})
   end
 
   def fake_request(hash)
-    EasyTranslate::Translation::TranslationRequest.should_receive(:new).and_return(OpenStruct.new(hash))
+    expect(EasyTranslate::Translation::TranslationRequest).to receive(:new).and_return(OpenStruct.new(hash))
   end
 
   klass = EasyTranslate::Translation::TranslationRequest
@@ -40,7 +40,7 @@ describe EasyTranslate::Translation do
       
       it 'should have a valid path' do
         request = klass.new('abc', :to => 'en')
-        request.path.should_not be_empty
+        expect(request.path).not_to be_empty
       end
 
     end
@@ -48,15 +48,15 @@ describe EasyTranslate::Translation do
     describe :initialize do
 
       it 'should raise an error when there is no to given' do
-        lambda do
+        expect do
           req = klass.new('abc', :from => 'en')
-        end.should raise_error ArgumentError
+        end.to raise_error ArgumentError
       end
 
       it 'should raise an error when tos are given as an array' do
-        lambda do
+        expect do
           req = klass.new('abc', :from => 'en', :to => ['es', 'de'])
-        end.should raise_error ArgumentError
+        end.to raise_error ArgumentError
       end
 
     end
@@ -65,81 +65,81 @@ describe EasyTranslate::Translation do
 
       it 'should include from in params if given' do
         req = klass.new('abc', :from => 'en', :to => 'es')
-        req.params[:source].should == 'en'
+        expect(req.params[:source]).to eq('en')
       end
 
       it 'should not include from by default' do
         req = klass.new('abc', :to => 'es')
-        req.params[:source].should be_nil
+        expect(req.params[:source]).to be_nil
       end
 
       it 'should include to' do
         req = klass.new('abc', :to => 'es')
-        req.params[:target].should == 'es'
+        expect(req.params[:target]).to eq('es')
       end
 
       it 'should not include format by default' do
         req = klass.new('abc', :to => 'es')
-        req.params[:format].should be_nil
+        expect(req.params[:format]).to be_nil
       end
 
       it 'should not include format when given as false' do
         req = klass.new('abc', :html => false, :to => 'es')
-        req.params[:format].should be_nil
+        expect(req.params[:format]).to be_nil
       end
 
       it 'should include format when html is true' do
         req = klass.new('abc', :html => true, :to => 'es')
-        req.params[:format].should == 'html'
+        expect(req.params[:format]).to eq('html')
       end
 
       it 'should include format when specified as text' do
         req = klass.new('abc', :format => 'text', :to => 'es')
-        req.params[:format].should == 'text'
+        expect(req.params[:format]).to eq('text')
       end
 
       it 'should use default params' do
         EasyTranslate.api_key = 'abc'
         request = klass.new('abc', :to => 'es')
-        request.params[:key].should == 'abc'
+        expect(request.params[:key]).to eq('abc')
       end
 
       it 'should allow overriding of params' do
         EasyTranslate.api_key = 'abc'
         request = klass.new('abc', :key => 'def', :to => 'es')
-        request.params[:key].should == 'def'
+        expect(request.params[:key]).to eq('def')
       end
 
       it 'should allow overriding of key as api_key' do
         EasyTranslate.api_key = 'abc'
         request = klass.new('abc', :api_key => 'def', :to => 'es')
-        request.params[:key].should == 'def'
-        request.params[:api_key].should be_nil
+        expect(request.params[:key]).to eq('def')
+        expect(request.params[:api_key]).to be_nil
       end
 
       it 'should be able to supply a language as a string' do
         request = klass.new('abc', :to => 'es')
-        request.params[:target].should == 'es'
+        expect(request.params[:target]).to eq('es')
       end
 
       it 'should be able to supply a language as a symbol' do
         request = klass.new('abc', :to => :es)
-        request.params[:target].should == 'es'
+        expect(request.params[:target]).to eq('es')
       end
 
       it 'should be able to supply a language as a word' do
         request = klass.new('abc', :to => 'spanish')
-        request.params[:target].should == 'es'
+        expect(request.params[:target]).to eq('es')
       end
 
       it 'should be able to supply a language as a word symbol' do
         request = klass.new('abc', :to => :spanish)
-        request.params[:target].should == 'es'
+        expect(request.params[:target]).to eq('es')
       end
 
       it 'should fall back when a word is not in the lookup' do
         request = klass.new('abc', :to => 'zzz')
-        request.params[:target].should == 'zzz'
+        expect(request.params[:target]).to eq('zzz')
       end
 
     end
@@ -148,17 +148,17 @@ describe EasyTranslate::Translation do
 
       it 'should be true if multiple are passed' do
         request = klass.new(['abc', 'def'], :to => 'es')
-        request.should be_multi
+        expect(request).to be_multi
       end
 
       it 'should be true if one is passed, but in an array' do
         request = klass.new(['abc'], :to => 'es')
-        request.should be_multi
+        expect(request).to be_multi
       end
 
       it 'should be true if one is passed as a string' do
         request = klass.new('abc', :to => 'es')
-        request.should_not be_multi
+        expect(request).not_to be_multi
       end
 
     end
@@ -167,17 +167,17 @@ describe EasyTranslate::Translation do
 
       it 'should insert the texts into the body' do
         request = klass.new(['abc', 'def'], :to => 'es')
-        request.body.should == 'q=abc&q=def'
+        expect(request.body).to eq('q=abc&q=def')
       end
 
       it 'should insert the text into the body' do
         request = klass.new('abc', :to => 'es')
-        request.body.should == 'q=abc'
+        expect(request.body).to eq('q=abc')
       end
 
       it 'should URI escape the body' do
         request = klass.new('%', :to => 'es')
-        request.body.should == 'q=%25'
+        expect(request.body).to eq('q=%25')
       end
 
     end

--- a/spec/examples/translation_target_spec.rb
+++ b/spec/examples/translation_target_spec.rb
@@ -7,31 +7,31 @@ describe klass do
 
     it 'should include target in params if given' do
       req = klass.new('en')
-      req.params[:target].should == 'en'
+      expect(req.params[:target]).to eq('en')
     end
 
     it 'should not include target by default' do
       req = klass.new
-      req.params[:target].should be_nil
+      expect(req.params[:target]).to be_nil
     end
 
     it 'should use default key' do
       EasyTranslate.api_key = 'abc'
       request = klass.new('en')
-      request.params[:key].should == 'abc'
+      expect(request.params[:key]).to eq('abc')
     end
 
     it 'should allow overriding of params' do
       EasyTranslate.api_key = 'abc'
       request = klass.new('en', :key => 'def')
-      request.params[:key].should == 'def'
+      expect(request.params[:key]).to eq('def')
     end
 
     it 'should allow overriding of key as api_key' do
       EasyTranslate.api_key = 'abc'
       request = klass.new('abc', :api_key => 'def', :to => 'es')
-      request.params[:key].should == 'def'
-      request.params[:api_key].should be_nil
+      expect(request.params[:key]).to eq('def')
+      expect(request.params[:api_key]).to be_nil
     end
 
   end


### PR DESCRIPTION
This conversion is done by Transpec 1.12.0 with the following command:
    transpec

* 62 conversions
    from: obj.should
      to: expect(obj).to

* 46 conversions
    from: == expected
      to: eq(expected)

* 6 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 4 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 3 conversions
    from: lambda { }.should
      to: expect { }.to