### PR TITLE
Add license to gemspec

### DIFF
--- a/easy_translate.gemspec
+++ b/easy_translate.gemspec
@@ -17,5 +17,6 @@ spec = Gem::Specification.new do |s|
   s.summary = 'Google Translate API Wrapper for Ruby'
   s.test_files = Dir.glob('spec/*.rb')
   s.version = EasyTranslate::VERSION
+  s.license = 'MIT'
 end
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.