### PR TITLE
Update googleapi hostname to support premium (NMT)

### DIFF
--- a/lib/easy_translate/request.rb
+++ b/lib/easy_translate/request.rb
@@ -52,7 +52,7 @@ module EasyTranslate
     private
 
     def uri
-      @uri ||= URI.parse("https://www.googleapis.com#{path}?#{param_s}")
+      @uri ||= URI.parse("https://translation.googleapis.com#{path}?#{param_s}")
     end
 
     def http


### PR DESCRIPTION
Per https://cloud.google.com/translate/docs/premium they have a new hostname for the endpoints, so this is the first change needed to support their NMT edition.  I'll let you know if I find other changes needed for our use.

Thanks for the gem!