### PR TITLE
Remove json

### DIFF
--- a/easy_translate.gemspec
+++ b/easy_translate.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path('lib/easy_translate/version', File.dirname(__FILE__))
 
 spec = Gem::Specification.new do |s|
-  s.name = 'easy_translate'  
+  s.name = 'easy_translate'
   s.author = 'John Crepezzi'
   s.add_development_dependency('rspec')
   s.add_dependency 'thread'
@@ -18,4 +18,3 @@ spec = Gem::Specification.new do |s|
   s.version = EasyTranslate::VERSION
   s.license = 'MIT'
 end
-

--- a/easy_translate.gemspec
+++ b/easy_translate.gemspec
@@ -4,7 +4,6 @@ spec = Gem::Specification.new do |s|
   s.name = 'easy_translate'  
   s.author = 'John Crepezzi'
   s.add_development_dependency('rspec')
-  s.add_dependency('json')
   s.add_dependency 'thread'
   s.add_dependency 'thread_safe'
   s.description = 'easy_translate is a wrapper for the google translate API that makes sense programatically, and implements API keys'


### PR DESCRIPTION
This change is based on that commit:

<https://github.com/rails/rails/commit/f3433f7c>

> All modern Rubies ship JSON as part of stdlib. Using the
> gem actually hurts multi-platform support due to build
> difficulties on Windows.
