### PR TITLE
identify simplified chinese additionally as zh-CN

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ https://github.com/seejohnrun/easy_translate/contributors
 
 (The MIT License)
 
-Copyright © 2010-2011 John Crepezzi
+Copyright © 2010-2018 John Crepezzi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the ‘Software’), to deal in

--- a/lib/easy_translate/translation_target.rb
+++ b/lib/easy_translate/translation_target.rb
@@ -12,9 +12,13 @@ module EasyTranslate
     def translations_available(target = nil, options = {})
       request = TranslationTargetRequest.new(target, options)
       raw = request.perform_raw
-      JSON.parse(raw)['data']['languages'].map do |res|
+      languages = JSON.parse(raw)['data']['languages'].map do |res|
         res['language']
       end
+
+      languages.push('zh-CN') if !languages.index('zh').nil?
+
+      languages
     end
 
     class TranslationTargetRequest < EasyTranslate::Request

--- a/spec/examples/translation_spec.rb
+++ b/spec/examples/translation_spec.rb
@@ -29,6 +29,11 @@ describe EasyTranslate::Translation do
     expect(trans).to eq(%{Hallo ' & " Welt})
   end
 
+  it 'should detect simplified chinese as zh-CN' do
+    expect(EasyTranslate.translations_available.include?('zh-CN')).to eq(true)
+    expect(EasyTranslate.translations_available.include?('zh')).to eq(true)
+  end
+
   def fake_request(hash)
     expect(EasyTranslate::Translation::TranslationRequest).to receive(:new).and_return(OpenStruct.new(hash))
   end
@@ -37,7 +42,7 @@ describe EasyTranslate::Translation do
   describe klass do
 
     describe :path do
-      
+
       it 'should have a valid path' do
         request = klass.new('abc', :to => 'en')
         expect(request.path).not_to be_empty


### PR DESCRIPTION
As stated at the bottom part of https://cloud.google.com/translate/docs/languages

> Simplified Chinese may be specified either by zh-CN or zh.

In order to make the API consistent but still keep backward compatibility, I offer the following solution

```ruby
EasyTranslate.detect('简体中文') # => 'zh'
EasyTranslate.translations_available.include?('zh') => true
```

```ruby
EasyTranslate.detect('简体中文') # => 'zh-CH'
EasyTranslate.translations_available.include?('zh-CH') => true
```

solves #44 