### PR TITLE
Add note about being grpc dependency free

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This is a Ruby library for Google Translate that makes working with bulk calls,
 user_ips and access via API Key easy.
 
+Unlike the official google client, `easy_translate` does not have a dependency on the `grpc` gem. This is a huge advantage because `grpc` can be extremely difficult to install on some systems or configurations.
+
 ---
 
 ### Installation


### PR DESCRIPTION
This is the feature that led me to use this library today.

I was happily using the official google client then today I went to upgrade to Ruby 3.1 and Rails 7, which resulting in the inability to install grpc on my server. This gem has no dependency on it so it worked without a hitch. 