### PR TITLE
Rescue unexpected parsing error when request status is 500

### DIFF
--- a/lib/easy_translate/request.rb
+++ b/lib/easy_translate/request.rb
@@ -42,14 +42,19 @@ module EasyTranslate
       request.body = body
       # Fire and return
       response = http.request(request)
-      unless response.code == '200'
-        err = JSON.parse(response.body)['error']['errors'].first['message']
-        raise EasyTranslateException.new(err)
-      end
+      raise_exception(response) unless response.code == '200'
       response.body
     end
 
     private
+
+    def raise_exception(response)
+      err = JSON.parse(response.body)['error']['errors'].first['message']
+    rescue JSON::ParserError => _e
+      err = "#{response.code} - #{response.message}"
+    ensure
+      raise EasyTranslateException.new(err)
+    end
 
     def uri
       @uri ||= URI.parse("https://translation.googleapis.com#{path}?#{param_s}")

--- a/spec/examples/real_world_spec.rb
+++ b/spec/examples/real_world_spec.rb
@@ -20,12 +20,12 @@ describe EasyTranslate do
 
     it 'should be able to translate multiple' do
       res = EasyTranslate.translate ['hello world', 'i love you'], :to => :spanish
-      expect(res).to eq(['Hola Mundo', 'te amo'])
+      expect(res).to eq(['Hola Mundo', 'te quiero'])
     end
 
     it 'should work concurrently' do
       res = EasyTranslate.translate ['hello world', 'i love you', 'good morning'], :to => :spanish, :concurrency => 2, :batch_size => 1
-      expect(res).to eq(['Hola Mundo', 'te amo', 'Buenos días'])
+      expect(res).to eq(['Hola Mundo', 'te quiero', 'Buenos días'])
     end
   end
 

--- a/spec/examples/translation_spec.rb
+++ b/spec/examples/translation_spec.rb
@@ -29,9 +29,17 @@ describe EasyTranslate::Translation do
     expect(trans).to eq(%{Hallo ' & " Welt})
   end
 
-  it 'should detect simplified chinese as zh-CN' do
-    expect(EasyTranslate.translations_available.include?('zh-CN')).to eq(true)
-    expect(EasyTranslate.translations_available.include?('zh')).to eq(true)
+  context 'detecting availale language' do
+    before :each do
+      pending 'please provide an API_KEY for this suite' if ENV['API_KEY'].nil?
+
+      EasyTranslate.api_key = ENV['API_KEY']
+    end
+
+    it 'should detect simplified chinese as zh-CN' do
+      expect(EasyTranslate.translations_available.include?('zh-CN')).to eq(true)
+      expect(EasyTranslate.translations_available.include?('zh')).to eq(true)
+    end
   end
 
   def fake_request(hash)


### PR DESCRIPTION
During unexpected situations when Google's service returns a 500 error, e.g. getting a 503 when you are making too many requests and are temporarily blocked, the response body is in HTML and therefore will raise an exception with JSON.parse.

In such cases, it would be better to fall back to the response code and message.

Also, updated some of the failing (outdated) tests.