### PR TITLE
Fix for 'Invalid JSON payload'

### DIFF
--- a/lib/easy_translate/detection.rb
+++ b/lib/easy_translate/detection.rb
@@ -21,8 +21,8 @@ module EasyTranslate
       request = DetectionRequest.new(texts, options, http_options)
       raw = request.perform_raw
       detections = JSON.parse(raw)['data']['detections'].map do |res|
-        res.empty? ? nil : 
-          options[:confidence] ? 
+        res.empty? ? nil :
+          options[:confidence] ?
             { :language => res.first['language'], :confidence => res.first['confidence'] } : res.first['language']
       end
     end
@@ -56,9 +56,9 @@ module EasyTranslate
       end
 
       # The body for the request
-      # @return [String] the body for the request, URL escaped
+      # @return [String] the body for the request
       def body
-        @texts.map { |t| "q=#{CGI::escape(t)}" }.join '&'
+        JSON.generate({ q: @texts })
       end
 
       # Whether or not this was a request for multiple texts

--- a/lib/easy_translate/request.rb
+++ b/lib/easy_translate/request.rb
@@ -36,11 +36,8 @@ module EasyTranslate
     # Perform the given request
     # @return [String] The response String
     def perform_raw
-      # Construct the request
-      request = Net::HTTP::Post.new(uri.request_uri)
-      request.add_field('X-HTTP-Method-Override', 'GET')
+      request = Net::HTTP::Post.new(uri.request_uri, { 'Content-Type' => 'application/json' })
       request.body = body
-      # Fire and return
       response = http.request(request)
       raise_exception(response) unless response.code == '200'
       response.body

--- a/lib/easy_translate/translation.rb
+++ b/lib/easy_translate/translation.rb
@@ -81,9 +81,9 @@ module EasyTranslate
       end
 
       # The body for the request
-      # @return [String] the body for the request, URL escaped
+      # @return [String] the body for the request
       def body
-        @texts.map { |t| "q=#{CGI::escape(t)}" }.join '&'
+        JSON.generate({ q: @texts })
       end
 
       # Whether or not this was a request for multiple texts

--- a/spec/examples/detection_spec.rb
+++ b/spec/examples/detection_spec.rb
@@ -53,22 +53,17 @@ describe EasyTranslate::Detection do
     end
 
     describe :body do
-
-      it 'should insert the texts into the body' do
+      it 'should insert the texts into a JSON-encoded body' do
         request = klass.new(['abc', 'def'])
-        expect(request.body).to eq('q=abc&q=def')
+        parsed_payload = JSON.parse(request.body)
+        expect(parsed_payload).to eq({ 'q' => ['abc', 'def'] })
       end
 
-      it 'should insert the text into the body' do
+      it 'should insert the text into a JSON-encoded body' do
         request = klass.new('abc')
-        expect(request.body).to eq('q=abc')
+        parsed_payload = JSON.parse(request.body)
+        expect(parsed_payload).to eq({ 'q' => ['abc'] })
       end
-
-      it 'should URI escape the body' do
-        request = klass.new('%')
-        expect(request.body).to eq('q=%25')
-      end
-
     end
 
     describe :params do

--- a/spec/examples/real_world_spec.rb
+++ b/spec/examples/real_world_spec.rb
@@ -12,20 +12,19 @@ describe EasyTranslate do
   end
 
   describe :translate do
-
     it 'should be able to translate one' do
       res = EasyTranslate.translate 'hello world', :to => :spanish
       expect(res).to eq('Hola Mundo')
     end
 
     it 'should be able to translate multiple' do
-      res = EasyTranslate.translate ['hello world', 'i love you'], :to => :spanish
-      expect(res).to eq(['Hola Mundo', 'te quiero'])
+      res = EasyTranslate.translate ['hello world', 'good afternoon'], :to => :spanish
+      expect(res).to eq(['Hola Mundo', 'buenas tardes'])
     end
 
     it 'should work concurrently' do
-      res = EasyTranslate.translate ['hello world', 'i love you', 'good morning'], :to => :spanish, :concurrency => 2, :batch_size => 1
-      expect(res).to eq(['Hola Mundo', 'te quiero', 'Buenos días'])
+      res = EasyTranslate.translate ['hello world', 'good afternoon', 'i can translate text'], :to => :spanish, :concurrency => 2, :batch_size => 1
+      expect(res).to eq(['Hola Mundo', 'buenas tardes', 'Puedo traducir texto'])
     end
   end
 

--- a/spec/examples/translation_spec.rb
+++ b/spec/examples/translation_spec.rb
@@ -177,20 +177,16 @@ describe EasyTranslate::Translation do
     end
 
     describe :body do
-
-      it 'should insert the texts into the body' do
+      it 'should insert the texts into a JSON-encoded body' do
         request = klass.new(['abc', 'def'], :to => 'es')
-        expect(request.body).to eq('q=abc&q=def')
+        parsed_payload = JSON.parse(request.body)
+        expect(parsed_payload).to eq( { 'q' => ['abc', 'def'] } )
       end
 
-      it 'should insert the text into the body' do
+      it 'should insert the text into a JSON-encoded body' do
         request = klass.new('abc', :to => 'es')
-        expect(request.body).to eq('q=abc')
-      end
-
-      it 'should URI escape the body' do
-        request = klass.new('%', :to => 'es')
-        expect(request.body).to eq('q=%25')
+        parsed_payload = JSON.parse(request.body)
+        expect(parsed_payload).to eq( { 'q' => ['abc'] } )
       end
 
     end


### PR DESCRIPTION
Fixes #59

Update request methods to current API requirements

The library previously sent translation/detection POST requests with a URL-encoded form submission body — though without the corresponding `Content-Type: application/x-www-form-urlencoded` header. 

It looks like this was a strategy to maximise the amount of text that could be sent in a single request — based on a [mirror](https://download.huihoo.com/google/gdgdevkit/DVD1/developers.google.com/translate/v2/using_rest.html) of an ancient version of the Google Translate API docs, clients could previously either pass up to 2,000 characters of text in a `q` query parameter with a GET request, or up to 5,000 if sent in the body of a POST request that set the header `X-HTTP-Method-Override: GET`.

The Google Translate API v2 seems to have previously tolerated the lack of a content type header — inferring it from the body — but at some point in the fall of 2025 the API started treating these as (malformed) JSON requests:
```shell
< HTTP/2 400 
< vary: X-Origin
< vary: Referer
< vary: Origin,Accept-Encoding
< content-type: application/json; charset=UTF-8
< date: Wed, 05 Nov 2025 11:37:57 GMT
< server: ESF
< x-xss-protection: 0
< x-frame-options: SAMEORIGIN
< x-content-type-options: nosniff
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
< accept-ranges: none
< 
{
  "error": {
    "code": 400,
    "message": "Invalid JSON payload received. Unexpected token.\nq=hello+world\n^",
    "errors": [
      {
        "message": "Invalid JSON payload received. Unexpected token.\nq=hello+world\n^",
        "domain": "global",
        "reason": "parseError"
      }
    ],
    "status": "INVALID_ARGUMENT"
  }
}
```

From an experiment, requests with a URL-encoded form submission body _do_ still succeed if a `Content-Type: application/x-www-form-urlencoded` header is provided.

However, given that today's Cloud Translation [docs](https://docs.cloud.google.com/translate/docs/overview) for v2 only give information on JSON requests, it's reasonable to assume that any other format (even if it "works") is unsupported, and might be withdrawn without notice. Therefore this PR switches to the JSON-based format that is officially documented as of November 2025.

Also removes the `X-HTTP-Method-Override: POST` header, which appears to no longer be necessary if we're departing from the original workaround for increasing limits (and also isn't mentioned in today's docs). [Request limits](https://docs.cloud.google.com/translate/quotas) (at least when using a JSON body) are now much higher than when this library was first written: 100,000 characters per request.